### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Benchmark Rust Rhai
 
-very simple benchmarking, Rust vs Rhai script (Direct) and Rhai (AST) that culculates the 1 to 10th Fibonacci number.
+very simple benchmarking, Rust vs Rhai script (Direct) and Rhai (AST) that calculates the 1 to 10th Fibonacci number.
 
 ## How to run
 


### PR DESCRIPTION
## Summary
- correct a typo in README

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_684054e6baa08328a5b15cab6dc83429